### PR TITLE
Feat/lint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,5 @@
+trailingComma: all
+printWidth: 140
+tabWidth: 4
+arrowParens: always
+bracketSpacing: true

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -3,3 +3,4 @@ printWidth: 140
 tabWidth: 4
 arrowParens: always
 bracketSpacing: true
+singleQuote: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ install:
   - npm install
 script:
   - npm run build 
-  #- npm run lint
+  - npm run lint
   - npm test
-  # Add more here
 after_failure:
   - "cat /home/travis/builds/Cosium/dry-dry/npm-debug.log"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 script:
   - npm run build 
   - npm run lint
+  - npm run style
   - npm test
 after_failure:
   - "cat /home/travis/builds/Cosium/dry-dry/npm-debug.log"

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 ### Get it
 
 ```bash
-npm i -g dry-dry
+$ npm i -g dry-dry
 ```
 
 ### Use it
 
 ```bash
-dry init
+$ dry init
 ```
 
 ### The copy/paste madness

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status][travis-image]][travis-url]
+[![code style: prettier][prettier-image]][prettier-url]
 
 # DRY - Use npm across multiple projects without repeating yourself
 
@@ -9,6 +10,7 @@ npm i -g dry-dry
 ```
 
 ### Use it
+
 ```bash
 dry init
 ```
@@ -16,7 +18,7 @@ dry init
 ### The copy/paste madness
 
 Because companies and other groups have bunch of `package.json` attributes that are the same across all npm projects.
-Those attributes must be maintained using copy/past across all projects. 
+Those attributes must be maintained using copy/paste across all projects.
 This is wrong !
 
 We believe that those attributes should be easily distributed and updated across projects.
@@ -29,10 +31,11 @@ The parent file can be located on the system or simply inside a published npm mo
 ### How does it work
 
 On each `dry` command, `dry`:
-- creates a merged `package.json` based on the provided `package-dry.json`
-- runs the `npm` command
-- applies the possible `package.json` modifications made by `npm` to `package-dry.json`
-- removes `package.json`
+
+* creates a merged `package.json` based on the provided `package-dry.json`
+* runs the `npm` command
+* applies the possible `package.json` modifications made by `npm` to `package-dry.json`
+* removes `package.json`
 
 `package.json` is always removed to make sure that nobody will execute a pure `npm` command in a `dry` project.
 
@@ -43,43 +46,45 @@ On each `dry` command, `dry`:
 ##### Parent project
 
 package-dry.json
+
 ```json
 {
-  "name": "parent",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "foo": "npm help"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
+    "name": "parent",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "foo": "npm help"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC"
 }
 ```
 
 ##### Child project
 
 package-dry.json
+
 ```json
 {
-  "name": "child",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "dry": {
-    "extends": "parent/package-dry.json",
-    "dependencies": {
-      "parent": "1.0.0"
+    "name": "child",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dry": {
+        "extends": "parent/package-dry.json",
+        "dependencies": {
+            "parent": "1.0.0"
+        }
     }
-  }
 }
 ```
 
@@ -90,21 +95,24 @@ To do that, `dry` introduces a file named `package-dry.json`.
 Of course, it can contain all the attributes of `package.json` with the addition of an attribute called `dry`.
 
 package-dry.json `dry` attribute has 2 optional attributes:
-- `extends` - The parent of the current dry package
-- `dependencies` - The dependencies needed to resolve the file pointed by `extends`. Those dependencies will not be saved to your project.
+
+* `extends` - The parent of the current dry package
+* `dependencies` - The dependencies needed to resolve the file pointed by `extends`. Those dependencies will not be saved to your project.
 
 ### dry commands
 
 `dry` proxies all received arguments to `npm`.
 Just take your usual npm commands and replace the word `npm` with `dry`.
 
-npm | dry
----------|-------------
-npm init | dry init
-npm i | dry i
-npm install | dry install
-npm publish | dry publish
-npm x y z | dry x y z
+| npm         | dry         |
+| ----------- | ----------- |
+| npm init    | dry init    |
+| npm i       | dry i       |
+| npm install | dry install |
+| npm publish | dry publish |
+| npm x y z   | dry x y z   |
 
 [travis-image]: https://travis-ci.org/Cosium/dry-dry.svg?branch=master
 [travis-url]: https://travis-ci.org/Cosium/dry-dry
+[prettier-image]: https://img.shields.io/badge/code_style-prettier-ff69b4.svg
+[prettier-url]: https://github.com/prettier/prettier

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## DRY - Use npm across multiple projects without repeating yourself
+[![Build Status][travis-image]][travis-url]
+
+# DRY - Use npm across multiple projects without repeating yourself
 
 ### Get it
 
@@ -103,3 +105,6 @@ npm i | dry i
 npm install | dry install
 npm publish | dry publish
 npm x y z | dry x y z
+
+[travis-image]: https://travis-ci.org/Cosium/dry-dry.svg?branch=master
+[travis-url]: https://travis-ci.org/Cosium/dry-dry

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,15 @@
       "integrity": "sha512-MobK1xxjn+OhT588IhpcGWxcNuQRZsbI3NURgdide6F8u17PWQI9GravRX51WvcKoKVgzpoi67iYdaTCv+g8MA==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.3.0"
+      }
+    },
     "@types/minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1257,6 +1257,12 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "dev": true
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "fs-extra": "5.0.0",
     "google-ts-style": "0.2.0",
     "mocha": "5.0.0",
+    "prettier": "1.10.2",
     "rimraf": "2.6.2",
     "ts-node": "4.1.0",
     "tslint": "5.9.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "rimraf ./dist && tsc",
     "test": "mocha -r ts-node/register src/**/*.test.ts",
     "lint": "tslint -p .",
+    "style": "prettier -l \"src/**/*.ts\"",
     "release": "npm run build && npm test && npm version minor && git push && git push --tags && npm publish"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/deep-diff": "0.0.31",
     "@types/deep-equal": "1.0.1",
     "@types/deepmerge": "1.3.3",
+    "@types/fs-extra": "5.0.0",
     "@types/minimist": "1.2.0",
     "@types/mocha": "2.2.46",
     "@types/node": "9.3.0",
@@ -47,6 +48,7 @@
     "mocha": "5.0.0",
     "rimraf": "2.6.2",
     "ts-node": "4.1.0",
+    "tslint": "5.9.1",
     "typescript": "2.6.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "rimraf ./dist && tsc",
     "test": "mocha -r ts-node/register src/**/*.test.ts",
+    "lint": "tslint -p .",
     "release": "npm run build && npm test && npm version minor && git push && git push --tags && npm publish"
   },
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import * as childProcess from 'child_process';
+import * as childProcess from "child_process";
 import Process = NodeJS.Process;
 
 /**
@@ -8,25 +8,23 @@ import Process = NodeJS.Process;
 export class Cli {
     /**
      * @param {NodeJS.Process} process The main process
+     * @return {Cli} A new command line interface
      */
-    private constructor(private readonly process: Process) {
-
+    public static of(process: Process): Cli {
+        return new Cli(process);
     }
 
     /**
      * @param {NodeJS.Process} process The main process
-     * @return {Cli} A new command line interface
      */
-    static of(process: Process): Cli {
-        return new Cli(process);
-    }
+    private constructor(private readonly process: Process) {}
 
     /**
      * Executes the provided command line on the system
      * @param {string} commandLine The command line to execute
      * @return {Promise<void>} A resolved promise in case of success, rejected in case of failure
      */
-    execute(commandLine: string): Promise<void> {
+    public execute(commandLine: string): Promise<void> {
         return new Promise((resolve, reject) => {
             const child = childProcess.exec(commandLine, (error: Error | null) => {
                 if (error) {
@@ -38,6 +36,6 @@ export class Cli {
             child.stderr.pipe(this.process.stderr);
             child.stdout.pipe(this.process.stdout);
             this.process.stdin.pipe(child.stdin);
-        })
+        });
     }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,16 +8,16 @@ import Process = NodeJS.Process;
 export class Cli {
     /**
      * @param {NodeJS.Process} process The main process
+     */
+    private constructor(private readonly process: Process) {}
+
+    /**
+     * @param {NodeJS.Process} process The main process
      * @return {Cli} A new command line interface
      */
     public static of(process: Process): Cli {
         return new Cli(process);
     }
-
-    /**
-     * @param {NodeJS.Process} process The main process
-     */
-    private constructor(private readonly process: Process) {}
 
     /**
      * Executes the provided command line on the system

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import * as childProcess from "child_process";
+import * as childProcess from 'child_process';
 import Process = NodeJS.Process;
 
 /**

--- a/src/dependency-resolver.ts
+++ b/src/dependency-resolver.ts
@@ -1,5 +1,5 @@
-import { Cli } from "./cli";
-import { DryDependencies } from "./dry-dependencies";
+import { Cli } from './cli';
+import { DryDependencies } from './dry-dependencies';
 
 /**
  * Resolves dry dependencies
@@ -20,12 +20,12 @@ export class DependencyResolver {
         const args: string[] = [];
         Object.keys(dependencies).forEach((dependencyName) => {
             const dependencyVersion = dependencies[dependencyName];
-            if (dependencyVersion && dependencyVersion.indexOf(":") !== 1) {
+            if (dependencyVersion && dependencyVersion.indexOf(':') !== 1) {
                 args.push(dependencyVersion);
             } else {
                 let arg = dependencyName;
                 if (dependencyVersion) {
-                    arg += "@" + dependencyVersion;
+                    arg += '@' + dependencyVersion;
                 }
                 args.push(arg);
             }
@@ -33,6 +33,6 @@ export class DependencyResolver {
         if (args.length === 0) {
             return Promise.resolve();
         }
-        return this.cli.execute("npm install --no-save " + args.join(" "));
+        return this.cli.execute('npm install --no-save ' + args.join(' '));
     }
 }

--- a/src/dependency-resolver.ts
+++ b/src/dependency-resolver.ts
@@ -1,17 +1,14 @@
-import {Cli} from "./cli";
-import {DryDependencies} from "./dry-dependencies";
+import { Cli } from "./cli";
+import { DryDependencies } from "./dry-dependencies";
 
 /**
  * Resolves dry dependencies
  */
 export class DependencyResolver {
-
     /**
      * @param {Cli} cli The cli to use
      */
-    constructor(private readonly cli: Cli) {
-
-    }
+    constructor(private readonly cli: Cli) {}
 
     /**
      * Resolves provided dry dependencies by fetching them if necessary.
@@ -19,28 +16,23 @@ export class DependencyResolver {
      * @param {DryDependencies} dependencies The dependencies to resolve
      * @return {Promise<void>} A resolved promise on success, rejected promise on failure.
      */
-    resolve(dependencies: DryDependencies): Promise<void> {
+    public resolve(dependencies: DryDependencies): Promise<void> {
         const args: string[] = [];
-        Object
-            .keys(dependencies)
-            .forEach(dependencyName => {
-                const dependencyVersion = dependencies[dependencyName];
-                if (dependencyVersion && dependencyVersion.indexOf(':') !== 1) {
-                    args.push(dependencyVersion);
-                } else {
-                    let arg = dependencyName;
-                    if (dependencyVersion) {
-                        arg += '@' + dependencyVersion;
-                    }
-                    args.push(arg);
+        Object.keys(dependencies).forEach((dependencyName) => {
+            const dependencyVersion = dependencies[dependencyName];
+            if (dependencyVersion && dependencyVersion.indexOf(":") !== 1) {
+                args.push(dependencyVersion);
+            } else {
+                let arg = dependencyName;
+                if (dependencyVersion) {
+                    arg += "@" + dependencyVersion;
                 }
-            });
+                args.push(arg);
+            }
+        });
         if (args.length === 0) {
             return Promise.resolve();
         }
-        return this
-            .cli
-            .execute('npm install --no-save ' + args.join(' '));
+        return this.cli.execute("npm install --no-save " + args.join(" "));
     }
-
 }

--- a/src/dry-dependencies.ts
+++ b/src/dry-dependencies.ts
@@ -1,4 +1,6 @@
 /**
  * Only dry requested dependencies should reside in this descriptor.
  */
-export type DryDependencies = { [key: string]: string };
+export interface DryDependencies {
+    [key: string]: string;
+}

--- a/src/dry-package-content.ts
+++ b/src/dry-package-content.ts
@@ -1,4 +1,4 @@
-import {DryPackageDescriptor} from "./dry-package-descriptor";
+import { DryPackageDescriptor } from "./dry-package-descriptor";
 
 /**
  * The content descriptor of the DryPackage

--- a/src/dry-package-content.ts
+++ b/src/dry-package-content.ts
@@ -1,4 +1,4 @@
-import { DryPackageDescriptor } from "./dry-package-descriptor";
+import { DryPackageDescriptor } from './dry-package-descriptor';
 
 /**
  * The content descriptor of the DryPackage

--- a/src/dry-package-descriptor.ts
+++ b/src/dry-package-descriptor.ts
@@ -1,4 +1,4 @@
-import {DryDependencies} from "./dry-dependencies";
+import { DryDependencies } from "./dry-dependencies";
 
 /**
  * The dry specific part of the DryPackage.

--- a/src/dry-package-descriptor.ts
+++ b/src/dry-package-descriptor.ts
@@ -1,4 +1,4 @@
-import { DryDependencies } from "./dry-dependencies";
+import { DryDependencies } from './dry-dependencies';
 
 /**
  * The dry specific part of the DryPackage.

--- a/src/dry-package.ts
+++ b/src/dry-package.ts
@@ -1,10 +1,11 @@
-import * as deepDiff from "deep-diff";
-import * as merge from "deepmerge";
-import * as fs from "fs";
-import { DependencyResolver } from "./dependency-resolver";
-import { DryPackageContent } from "./dry-package-content";
-import { JsonUtils } from "./json-utils";
-import { NpmPackage } from "./npm-package";
+import * as deepDiff from 'deep-diff';
+import * as merge from 'deepmerge';
+import * as fs from 'fs';
+
+import { DependencyResolver } from './dependency-resolver';
+import { DryPackageContent } from './dry-package-content';
+import { JsonUtils } from './json-utils';
+import { NpmPackage } from './npm-package';
 
 // TODO: consider adding a type to 'any'
 // tslint:disable-next-line:no-any
@@ -16,10 +17,10 @@ export type WeakDryPackageContent = DryPackageContent & any;
  */
 export class DryPackage {
     public static readFromDisk(dependencyResolver: DependencyResolver): DryPackage {
-        const location = "./" + DryPackage.PACKAGE_DRY_JSON;
-        let fileContent = "{}";
+        const location = './' + DryPackage.PACKAGE_DRY_JSON;
+        let fileContent = '{}';
         try {
-            fileContent = fs.readFileSync(location, "utf8");
+            fileContent = fs.readFileSync(location, 'utf8');
         } catch (e) {
             // TODO: Bad practice to silence exception
         }
@@ -27,7 +28,7 @@ export class DryPackage {
         return new DryPackage(dependencyResolver, location, baseDryPackage);
     }
 
-    private static readonly PACKAGE_DRY_JSON = "package-dry.json";
+    private static readonly PACKAGE_DRY_JSON = 'package-dry.json';
 
     private constructor(
         private readonly dependencyResolver: DependencyResolver,

--- a/src/dry-package.ts
+++ b/src/dry-package.ts
@@ -16,6 +16,15 @@ export type WeakDryPackageContent = DryPackageContent & any;
  * A dry package is an npm package added of a DryPackageDescriptor.
  */
 export class DryPackage {
+    private static readonly PACKAGE_DRY_JSON = 'package-dry.json';
+
+    private constructor(
+        private readonly dependencyResolver: DependencyResolver,
+        private readonly location: string,
+        // tslint:disable-next-line:variable-name
+        private _content: WeakDryPackageContent,
+    ) {}
+
     public static readFromDisk(dependencyResolver: DependencyResolver): DryPackage {
         const location = './' + DryPackage.PACKAGE_DRY_JSON;
         let fileContent = '{}';
@@ -27,15 +36,6 @@ export class DryPackage {
         const baseDryPackage = JSON.parse(fileContent);
         return new DryPackage(dependencyResolver, location, baseDryPackage);
     }
-
-    private static readonly PACKAGE_DRY_JSON = 'package-dry.json';
-
-    private constructor(
-        private readonly dependencyResolver: DependencyResolver,
-        private readonly location: string,
-        // tslint:disable-next-line:variable-name
-        private _content: WeakDryPackageContent,
-    ) {}
 
     public applyDiff(oldContent: WeakDryPackageContent, newContent: WeakDryPackageContent): void {
         const diffs = deepDiff.diff(oldContent, newContent);

--- a/src/dry-package.ts
+++ b/src/dry-package.ts
@@ -1,34 +1,60 @@
-import * as fs from 'fs';
-import * as deepDiff from 'deep-diff';
-import {DryPackageContent} from './dry-package-content';
-import {JsonUtils} from './json-utils';
-import {DependencyResolver} from './dependency-resolver';
-import {NpmPackage} from './npm-package';
-import * as merge from 'deepmerge';
+import * as deepDiff from "deep-diff";
+import * as merge from "deepmerge";
+import * as fs from "fs";
+import { DependencyResolver } from "./dependency-resolver";
+import { DryPackageContent } from "./dry-package-content";
+import { JsonUtils } from "./json-utils";
+import { NpmPackage } from "./npm-package";
+
+// TODO: consider adding a type to 'any'
+// tslint:disable-next-line:no-any
+export type WeakDryPackageContent = DryPackageContent & any;
 
 /**
  * The dry package (i.e. package-dry.json) is the pendant of the npm package (i.e. package.json).
  * A dry package is an npm package added of a DryPackageDescriptor.
  */
 export class DryPackage {
-
-    private static readonly PACKAGE_DRY_JSON = 'package-dry.json';
-
-    private constructor(private readonly dependencyResolver: DependencyResolver,
-                        private readonly location: string,
-                        private _content: DryPackageContent & any) {
-
-    };
-
-    static readFromDisk(dependencyResolver: DependencyResolver): DryPackage {
-        const location = './' + DryPackage.PACKAGE_DRY_JSON;
-        let fileContent = '{}';
+    public static readFromDisk(dependencyResolver: DependencyResolver): DryPackage {
+        const location = "./" + DryPackage.PACKAGE_DRY_JSON;
+        let fileContent = "{}";
         try {
-            fileContent = fs.readFileSync(location, 'utf8');
+            fileContent = fs.readFileSync(location, "utf8");
         } catch (e) {
+            // TODO: Bad practice to silence exception
         }
         const baseDryPackage = JSON.parse(fileContent);
         return new DryPackage(dependencyResolver, location, baseDryPackage);
+    }
+
+    private static readonly PACKAGE_DRY_JSON = "package-dry.json";
+
+    private constructor(
+        private readonly dependencyResolver: DependencyResolver,
+        private readonly location: string,
+        // tslint:disable-next-line:variable-name
+        private _content: WeakDryPackageContent,
+    ) {}
+
+    public applyDiff(oldContent: WeakDryPackageContent, newContent: WeakDryPackageContent): void {
+        const diffs = deepDiff.diff(oldContent, newContent);
+        if (!diffs) {
+            return;
+        }
+        diffs.forEach((diff) => deepDiff.applyChange(this._content, this._content, diff));
+        fs.writeFileSync(this.location, JsonUtils.prettyStringify(this._content));
+    }
+
+    public exists(): boolean {
+        return fs.existsSync(this.location);
+    }
+
+    /**
+     * Builds a NpmPackage
+     * @return {Promise<NpmPackage>} The NpmPackage
+     */
+    public buildNpmPackage(): Promise<NpmPackage> {
+        return this.doBuildNpmPackage();
     }
 
     /**
@@ -37,27 +63,6 @@ export class DryPackage {
      */
     private merge(dryPackage: DryPackage): void {
         this._content = merge(this._content, dryPackage._content);
-    }
-
-    applyDiff(oldContent: any, newContent: any): void {
-        const diffs = deepDiff.diff(oldContent, newContent);
-        if (!diffs) {
-            return;
-        }
-        diffs.forEach(diff => deepDiff.applyChange(this._content, this._content, diff));
-        fs.writeFileSync(this.location, JsonUtils.prettyStringify(this._content));
-    }
-
-    exists(): boolean {
-        return fs.existsSync(this.location);
-    }
-
-    /**
-     * Builds a NpmPackage
-     * @return {Promise<NpmPackage>} The NpmPackage
-     */
-    buildNpmPackage(): Promise<NpmPackage> {
-        return this.doBuildNpmPackage();
     }
 
     /**
@@ -74,19 +79,17 @@ export class DryPackage {
 
         collectedPackages.push(currentPackage);
 
-        return currentPackage
-            .getParent()
-            .then<NpmPackage>(parent => {
-                if (parent) {
-                    return this.doBuildNpmPackage(parent, collectedPackages);
-                } else {
-                    const mergedPackage = collectedPackages.pop();
-                    while (collectedPackages.length > 0) {
-                        mergedPackage.merge(collectedPackages.pop());
-                    }
-                    return new NpmPackage(mergedPackage);
+        return currentPackage.getParent().then<NpmPackage>((parent) => {
+            if (parent) {
+                return this.doBuildNpmPackage(parent, collectedPackages);
+            } else {
+                const mergedPackage = collectedPackages.pop();
+                while (collectedPackages.length > 0) {
+                    mergedPackage.merge(collectedPackages.pop());
                 }
-            });
+                return new NpmPackage(mergedPackage);
+            }
+        });
     }
 
     private getParent(): Promise<DryPackage> {
@@ -101,12 +104,10 @@ export class DryPackage {
         if (dry.dependencies) {
             promise = this.dependencyResolver.resolve(dry.dependencies);
         }
-        return promise
-            .then(() => new DryPackage(this.dependencyResolver, this.location, require(dry.extends)));
+        return promise.then(() => new DryPackage(this.dependencyResolver, this.location, require(dry.extends)));
     }
 
-    get content(): DryPackageContent & any {
+    public get content(): WeakDryPackageContent {
         return JSON.parse(JSON.stringify(this._content));
     }
-
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,15 +1,17 @@
-import * as fs from 'fs';
-import * as fsExtra from 'fs-extra';
-import * as childProcess from 'child_process';
-import * as path from 'path';
-import {expect} from 'chai';
-import {DryPackageContent} from "./dry-package-content";
-import deepEqual = require('deep-equal');
+// tslint:disable:no-unused-expression
+// tslint:disable:no-any
+import { expect } from "chai";
+import * as childProcess from "child_process";
+// tslint:disable-next-line:no-require-imports
+import deepEqual = require("deep-equal");
+import * as fs from "fs";
+import * as fsExtra from "fs-extra";
+import * as path from "path";
+import { DryPackageContent } from "./dry-package-content";
 
-describe('index', () => {
-
-    const dryIndexJs = path.resolve('dist/index.js');
-    const testDir = path.resolve('dist-test');
+describe("index", () => {
+    const dryIndexJs = path.resolve("dist/index.js");
+    const testDir = path.resolve("dist-test");
 
     const mkdirIfNotExist = (dir: string): void => {
         if (fs.existsSync(dir)) {
@@ -17,23 +19,23 @@ describe('index', () => {
         }
         fsExtra.mkdirsSync(dir);
     };
-    const readJson = (file: string): any => JSON.parse(fs.readFileSync(path.resolve(file), 'utf8'));
-    const writeJson = (file: string, obj: any): any => fs.writeFileSync(path.resolve(file), JSON.stringify(obj, null, 2) + '\n');
+    const readJson = (file: string): any => JSON.parse(fs.readFileSync(path.resolve(file), "utf8"));
+    const writeJson = (file: string, obj: any): any => fs.writeFileSync(path.resolve(file), JSON.stringify(obj, null, 2) + "\n");
 
     beforeEach(() => {
         fsExtra.removeSync(testDir);
         mkdirIfNotExist(testDir);
     });
 
-    describe('dry commands match npm commands', () => {
+    describe("dry commands match npm commands", () => {
         const executeAndAssertSame = (commands: string[], packageJson: boolean, lock: boolean) => {
             const withNpmDir = path.resolve(`${testDir}/with-npm/foo`);
             mkdirIfNotExist(withNpmDir);
             const withDryDir = path.resolve(`${testDir}/with-dry/foo`);
             mkdirIfNotExist(withDryDir);
 
-            commands.forEach(command => childProcess.execSync(`npm ${command}`, {cwd: withNpmDir}));
-            commands.forEach(command => childProcess.execSync(`node ${dryIndexJs} ${command}`, {cwd: withDryDir}));
+            commands.forEach((command) => childProcess.execSync(`npm ${command}`, { cwd: withNpmDir }));
+            commands.forEach((command) => childProcess.execSync(`node ${dryIndexJs} ${command}`, { cwd: withDryDir }));
 
             if (packageJson) {
                 expect(deepEqual(readJson(`${withDryDir}/package-dry.json`), readJson(`${withNpmDir}/package.json`))).to.be.true;
@@ -43,41 +45,39 @@ describe('index', () => {
             }
         };
 
-        it('init -f', () => executeAndAssertSame(['init -f'], true, false)).timeout(30000);
-        it('init -f && install', () => executeAndAssertSame(['init -f', 'install'], true, true)).timeout(30000);
-        it('init -f && install && pack', () => executeAndAssertSame(['init -f', 'install', 'pack'], true, true)).timeout(30000);
+        it("init -f", () => executeAndAssertSame(["init -f"], true, false)).timeout(30000);
+        it("init -f && install", () => executeAndAssertSame(["init -f", "install"], true, true)).timeout(30000);
+        it("init -f && install && pack", () => executeAndAssertSame(["init -f", "install", "pack"], true, true)).timeout(30000);
     });
 
-    describe('dry inheritance', () => {
-
-        it('inherits foo script when foo is defined in dry package parent', () => {
+    describe("dry inheritance", () => {
+        it("inherits foo script when foo is defined in dry package parent", () => {
             // Build parent
             const parentProject = path.resolve(`${testDir}/parent`);
             mkdirIfNotExist(parentProject);
-            childProcess.execSync(`node ${dryIndexJs} init -f`, {cwd: parentProject});
+            childProcess.execSync(`node ${dryIndexJs} init -f`, { cwd: parentProject });
             const parentDryPackage = readJson(path.resolve(`${parentProject}/package-dry.json`));
-            parentDryPackage.scripts.foo = 'npm help';
+            parentDryPackage.scripts.foo = "npm help";
             writeJson(`${parentProject}/package-dry.json`, parentDryPackage);
-            childProcess.execSync(`node ${dryIndexJs} pack`, {cwd: parentProject});
+            childProcess.execSync(`node ${dryIndexJs} pack`, { cwd: parentProject });
 
             // Build child
             const childProject = path.resolve(`${testDir}/child`);
             mkdirIfNotExist(childProject);
-            childProcess.execSync(`node ${dryIndexJs} init -f`, {cwd: childProject});
+            childProcess.execSync(`node ${dryIndexJs} init -f`, { cwd: childProject });
             const childDryPackage: DryPackageContent = readJson(path.resolve(`${childProject}/package-dry.json`));
             childDryPackage.dry = {
-                extends: 'parent/package-dry.json',
+                extends: "parent/package-dry.json",
                 dependencies: {
-                    parent: 'file:../parent/parent-1.0.0.tgz'
-                }
+                    parent: "file:../parent/parent-1.0.0.tgz",
+                },
             };
             writeJson(`${childProject}/package-dry.json`, childDryPackage);
 
             // Run the script
-            childProcess.execSync(`node ${dryIndexJs} run foo`, {cwd: childProject});
+            childProcess.execSync(`node ${dryIndexJs} run foo`, { cwd: childProject });
 
             expect(fs.existsSync(`${childProject}/package.json`)).to.be.false;
         }).timeout(30000);
-
     });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,17 +1,17 @@
 // tslint:disable:no-unused-expression
 // tslint:disable:no-any
-import { expect } from "chai";
-import * as childProcess from "child_process";
+import { expect } from 'chai';
+import * as childProcess from 'child_process';
 // tslint:disable-next-line:no-require-imports
-import deepEqual = require("deep-equal");
-import * as fs from "fs";
-import * as fsExtra from "fs-extra";
-import * as path from "path";
-import { DryPackageContent } from "./dry-package-content";
+import deepEqual = require('deep-equal');
+import * as fs from 'fs';
+import * as fsExtra from 'fs-extra';
+import * as path from 'path';
+import { DryPackageContent } from './dry-package-content';
 
-describe("index", () => {
-    const dryIndexJs = path.resolve("dist/index.js");
-    const testDir = path.resolve("dist-test");
+describe('index', () => {
+    const dryIndexJs = path.resolve('dist/index.js');
+    const testDir = path.resolve('dist-test');
 
     const mkdirIfNotExist = (dir: string): void => {
         if (fs.existsSync(dir)) {
@@ -19,15 +19,15 @@ describe("index", () => {
         }
         fsExtra.mkdirsSync(dir);
     };
-    const readJson = (file: string): any => JSON.parse(fs.readFileSync(path.resolve(file), "utf8"));
-    const writeJson = (file: string, obj: any): any => fs.writeFileSync(path.resolve(file), JSON.stringify(obj, null, 2) + "\n");
+    const readJson = (file: string): any => JSON.parse(fs.readFileSync(path.resolve(file), 'utf8'));
+    const writeJson = (file: string, obj: any): any => fs.writeFileSync(path.resolve(file), JSON.stringify(obj, null, 2) + '\n');
 
     beforeEach(() => {
         fsExtra.removeSync(testDir);
         mkdirIfNotExist(testDir);
     });
 
-    describe("dry commands match npm commands", () => {
+    describe('dry commands match npm commands', () => {
         const executeAndAssertSame = (commands: string[], packageJson: boolean, lock: boolean) => {
             const withNpmDir = path.resolve(`${testDir}/with-npm/foo`);
             mkdirIfNotExist(withNpmDir);
@@ -45,19 +45,19 @@ describe("index", () => {
             }
         };
 
-        it("init -f", () => executeAndAssertSame(["init -f"], true, false)).timeout(30000);
-        it("init -f && install", () => executeAndAssertSame(["init -f", "install"], true, true)).timeout(30000);
-        it("init -f && install && pack", () => executeAndAssertSame(["init -f", "install", "pack"], true, true)).timeout(30000);
+        it('init -f', () => executeAndAssertSame(['init -f'], true, false)).timeout(30000);
+        it('init -f && install', () => executeAndAssertSame(['init -f', 'install'], true, true)).timeout(30000);
+        it('init -f && install && pack', () => executeAndAssertSame(['init -f', 'install', 'pack'], true, true)).timeout(30000);
     });
 
-    describe("dry inheritance", () => {
-        it("inherits foo script when foo is defined in dry package parent", () => {
+    describe('dry inheritance', () => {
+        it('inherits foo script when foo is defined in dry package parent', () => {
             // Build parent
             const parentProject = path.resolve(`${testDir}/parent`);
             mkdirIfNotExist(parentProject);
             childProcess.execSync(`node ${dryIndexJs} init -f`, { cwd: parentProject });
             const parentDryPackage = readJson(path.resolve(`${parentProject}/package-dry.json`));
-            parentDryPackage.scripts.foo = "npm help";
+            parentDryPackage.scripts.foo = 'npm help';
             writeJson(`${parentProject}/package-dry.json`, parentDryPackage);
             childProcess.execSync(`node ${dryIndexJs} pack`, { cwd: parentProject });
 
@@ -67,9 +67,9 @@ describe("index", () => {
             childProcess.execSync(`node ${dryIndexJs} init -f`, { cwd: childProject });
             const childDryPackage: DryPackageContent = readJson(path.resolve(`${childProject}/package-dry.json`));
             childDryPackage.dry = {
-                extends: "parent/package-dry.json",
+                extends: 'parent/package-dry.json',
                 dependencies: {
-                    parent: "file:../parent/parent-1.0.0.tgz",
+                    parent: 'file:../parent/parent-1.0.0.tgz',
                 },
             };
             writeJson(`${childProject}/package-dry.json`, childDryPackage);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,17 @@
 #!/usr/bin/env node
-import {Cli} from "./cli";
-import {DependencyResolver} from "./dependency-resolver";
-import {DryPackage} from "./dry-package";
-import {NpmCommandProxy} from "./npm-command-proxy";
+import { Cli } from "./cli";
+import { DependencyResolver } from "./dependency-resolver";
+import { DryPackage } from "./dry-package";
+import { NpmCommandProxy } from "./npm-command-proxy";
 
 const cli = Cli.of(process);
 const npmCommandProxy = new NpmCommandProxy(cli, process);
 const dependencyResolver = new DependencyResolver(cli);
 
-DryPackage
-    .readFromDisk(dependencyResolver)
+DryPackage.readFromDisk(dependencyResolver)
     .buildNpmPackage()
-    .then(npmPackage => {
+    .then((npmPackage) => {
         npmPackage.beforeNpmRun();
-        return npmCommandProxy
-            .proxy()
-            .then(() => npmPackage.afterNpmRun());
+        return npmCommandProxy.proxy().then(() => npmPackage.afterNpmRun());
     })
     .then(() => process.exit(), () => process.exit(1));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import { Cli } from "./cli";
-import { DependencyResolver } from "./dependency-resolver";
-import { DryPackage } from "./dry-package";
-import { NpmCommandProxy } from "./npm-command-proxy";
+import { Cli } from './cli';
+import { DependencyResolver } from './dependency-resolver';
+import { DryPackage } from './dry-package';
+import { NpmCommandProxy } from './npm-command-proxy';
 
 const cli = Cli.of(process);
 const npmCommandProxy = new NpmCommandProxy(cli, process);

--- a/src/json-utils.ts
+++ b/src/json-utils.ts
@@ -8,6 +8,6 @@ export class JsonUtils {
      * @return {string} Pretty stringifies JSON
      */
     public static prettyStringify(obj: object): string {
-        return JSON.stringify(obj, null, 2) + "\n";
+        return JSON.stringify(obj, null, 2) + '\n';
     }
 }

--- a/src/json-utils.ts
+++ b/src/json-utils.ts
@@ -2,14 +2,12 @@
  * JSON utilities
  */
 export class JsonUtils {
-
     /**
      * Generates a JSON string using the NpmPackage JSON style.
      * @param obj
      * @return {string} Pretty stringifies JSON
      */
-    static prettyStringify(obj: any): string {
-        return JSON.stringify(obj, null, 2) + '\n';
+    public static prettyStringify(obj: object): string {
+        return JSON.stringify(obj, null, 2) + "\n";
     }
-
 }

--- a/src/npm-command-proxy.ts
+++ b/src/npm-command-proxy.ts
@@ -1,19 +1,17 @@
-import {Cli} from "./cli";
+import { Cli } from "./cli";
 import Process = NodeJS.Process;
 
 /**
  * Responsible for the requested npm command propagation
  */
 export class NpmCommandProxy {
-
     private readonly rawArgs: string[];
 
     /**
      * @param {Cli} cli The CLI to use
      * @param {NodeJS.Process} process The main process
      */
-    constructor(private readonly cli: Cli,
-                process: Process) {
+    constructor(private readonly cli: Cli, process: Process) {
         this.rawArgs = process.argv.slice(2);
     }
 
@@ -21,10 +19,7 @@ export class NpmCommandProxy {
      * Propagate the command received by dry to npm
      * @return {Promise<void>} Resolved promise on success, rejected promise on failure.
      */
-    proxy() {
-        return this
-            .cli
-            .execute(`npm ${this.rawArgs.join(' ')}`);
+    public proxy(): Promise<void> {
+        return this.cli.execute(`npm ${this.rawArgs.join(" ")}`);
     }
-
 }

--- a/src/npm-command-proxy.ts
+++ b/src/npm-command-proxy.ts
@@ -1,4 +1,4 @@
-import { Cli } from "./cli";
+import { Cli } from './cli';
 import Process = NodeJS.Process;
 
 /**
@@ -20,6 +20,6 @@ export class NpmCommandProxy {
      * @return {Promise<void>} Resolved promise on success, rejected promise on failure.
      */
     public proxy(): Promise<void> {
-        return this.cli.execute(`npm ${this.rawArgs.join(" ")}`);
+        return this.cli.execute(`npm ${this.rawArgs.join(' ')}`);
     }
 }

--- a/src/npm-package.ts
+++ b/src/npm-package.ts
@@ -1,7 +1,7 @@
-import * as fs from "fs";
+import * as fs from 'fs';
 
-import { DryPackage } from "./dry-package";
-import { JsonUtils } from "./json-utils";
+import { DryPackage } from './dry-package';
+import { JsonUtils } from './json-utils';
 
 /**
  * npm 'package.json' component
@@ -10,7 +10,7 @@ export class NpmPackage {
     /**
      * @type {string} The location of this NpmPackage
      */
-    private readonly location = "./package.json";
+    private readonly location = './package.json';
     /**
      * The content of this NpmPackage
      */
@@ -23,7 +23,7 @@ export class NpmPackage {
     constructor(private readonly dryPackage: DryPackage) {
         this.content = this.dryPackage.content;
         // tslint:disable-next-line:no-string-literal
-        delete this.content["dry"];
+        delete this.content['dry'];
     }
 
     /**
@@ -40,9 +40,9 @@ export class NpmPackage {
      * Called after npm command proxy
      */
     public afterNpmRun(): void {
-        let fileContent = "{}";
+        let fileContent = '{}';
         try {
-            fileContent = fs.readFileSync(this.location, "utf8");
+            fileContent = fs.readFileSync(this.location, 'utf8');
         } catch (e) {
             // TODO
         }

--- a/src/npm-package.ts
+++ b/src/npm-package.ts
@@ -1,19 +1,20 @@
-import {DryPackage} from "./dry-package";
 import * as fs from "fs";
-import {JsonUtils} from "./json-utils";
+
+import { DryPackage } from "./dry-package";
+import { JsonUtils } from "./json-utils";
 
 /**
  * npm 'package.json' component
  */
 export class NpmPackage {
-
     /**
      * @type {string} The location of this NpmPackage
      */
-    private readonly location = './package.json';
+    private readonly location = "./package.json";
     /**
      * The content of this NpmPackage
      */
+    // tslint:disable-next-line:no-any
     private readonly content: any;
 
     /**
@@ -21,13 +22,14 @@ export class NpmPackage {
      */
     constructor(private readonly dryPackage: DryPackage) {
         this.content = this.dryPackage.content;
-        delete this.content['dry'];
+        // tslint:disable-next-line:no-string-literal
+        delete this.content["dry"];
     }
 
     /**
      * Called before npm command proxy
      */
-    beforeNpmRun(): void {
+    public beforeNpmRun(): void {
         if (!this.dryPackage.exists()) {
             return;
         }
@@ -37,18 +39,18 @@ export class NpmPackage {
     /**
      * Called after npm command proxy
      */
-    afterNpmRun(): void {
-        let fileContent = '{}';
+    public afterNpmRun(): void {
+        let fileContent = "{}";
         try {
-            fileContent = fs.readFileSync(this.location, 'utf8');
+            fileContent = fs.readFileSync(this.location, "utf8");
         } catch (e) {
-
+            // TODO
         }
         this.dryPackage.applyDiff(this.content, JSON.parse(fileContent));
         try {
             fs.unlinkSync(this.location);
         } catch (e) {
-
+            // TODO
         }
     }
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,4 +1,0 @@
-declare module 'fs-extra' {
-    const removeSync: (path: string) => void;
-    const mkdirsSync: (path: string) => void;
-}

--- a/tslint.json
+++ b/tslint.json
@@ -36,6 +36,10 @@
         ],
         "no-implicit-dependencies": false,
         "no-submodule-imports": false,
-        "interface-name": false
+        "interface-name": false,
+        "quotemark": [
+            true,
+            "single"
+        ]
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -40,6 +40,12 @@
         "quotemark": [
             true,
             "single"
+        ],
+        "member-ordering": [
+            true,
+            {
+                "order": "fields-first"
+            }
         ]
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -36,14 +36,6 @@
         ],
         "no-implicit-dependencies": false,
         "no-submodule-imports": false,
-        "quotemark": [
-            true,
-            "single"
-        ],
-        "arrow-parens": [
-            true, 
-            "ban-single-arg-parens"
-        ],
         "interface-name": false
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,48 @@
+{
+    "extends": "tslint:latest",
+    "rules": {
+        "curly": true,
+        "one-variable-per-declaration": [
+            true
+        ],
+        "no-any": true,
+        "no-consecutive-blank-lines": [
+            true
+        ],
+        "no-require-imports": true,
+        "member-access": [
+            true
+        ],
+        "indent": [
+            true,
+            "spaces"
+        ],
+        "object-literal-sort-keys": false,
+        "object-literal-shorthand": false,
+        "typedef": [
+            true,
+            "call-signature",
+            "parameter",
+            "property-declaration"
+        ],
+        "max-line-length": [
+            false
+        ],
+        "max-classes-per-file": [
+            false
+        ],
+        "no-unused-variable": [
+            true
+        ],
+        "no-implicit-dependencies": false,
+        "no-submodule-imports": false,
+        "quotemark": [
+            true,
+            "single"
+        ],
+        "arrow-parens": [
+            true, 
+            "ban-single-arg-parens"
+        ]
+    }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -43,6 +43,7 @@
         "arrow-parens": [
             true, 
             "ban-single-arg-parens"
-        ]
+        ],
+        "interface-name": false
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Cosium/dry-dry/issues/6 and https://github.com/Cosium/dry-dry/issues/4

I have added my tslint file with 2 added rules:

`quotemark` and `arrow-parens`

I don't mind which quote mark to use, double or single, as long as its consistent

arrow-parens, i like enforcing to always use parens in whatever case, to keep consistency, but your opinion may be different to mine :P 

so:
```ts
doStuff((hello) => {})
doTwoStuff((hello, world) => {})
```

rather than:

```ts
doStuff(hello => {}) // special one param case
doTwoStuff((hello, world) => {})
```

But it's up to you